### PR TITLE
Make homepage title configurable

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -3,6 +3,8 @@ SESSION_SECRET=change_me
 DISABLE_AUTH="false"
 OPENAI_API_KEY=your_openai_api_key
 ASSISTANT_ID=your_assistant_id
+# Title displayed on the main page
+APP_TITLE="Cartographie hospitalière"
 # List of IP addresses allowed to access Nginx
 # Format: 'allow IP1; allow IP2;'
 ALLOWED_IPS="allow 172.18.0.1; deny;"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Variables d'environnement utiles :
 
 ```
 SESSION_SECRET="votre_secret"
+# Titre affiché sur la page principale
+APP_TITLE="Cartographie hospitalière"
 # Pour désactiver l'authentification (mode développement uniquement)
 # La valeur par défaut est "false" pour activer la connexion
 DISABLE_AUTH="false"

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
-  <title>Cartographie des Hôpitaux Publics de Corse</title>
+  <title>{{APP_TITLE}}</title>
 
   <style>
     /* ======== Styles généraux ======== */
@@ -90,7 +90,7 @@
 <body>
   <!-- ======== Bandeau héro ======== -->
   <header class="hero">
-    <h1>Cartographie des Hôpitaux Publics de Corse</h1>
+    <h1>{{APP_TITLE}}</h1>
     <p>Explorez les domaines, processus et applications.</p>
   </header>
 

--- a/server.js
+++ b/server.js
@@ -16,6 +16,7 @@ import bcrypt from 'bcryptjs';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 const PORT = process.env.PORT || 3000;
+const APP_TITLE = process.env.APP_TITLE || 'Cartographie hospitalière';
 
 const authDisabled = process.env.DISABLE_AUTH === 'true';
 
@@ -63,6 +64,23 @@ if (!authDisabled) {
     return res.status(401).json({ error: 'Not authenticated' });
   });
 }
+
+app.get('/', async (_req, res) => {
+  try {
+    const html = await fs.readFile(path.join(__dirname, 'public', 'index.html'), 'utf-8');
+    res.send(html.replace(/{{APP_TITLE}}/g, APP_TITLE));
+  } catch {
+    res.status(500).send('Index not found');
+  }
+});
+app.get('/index.html', async (_req, res) => {
+  try {
+    const html = await fs.readFile(path.join(__dirname, 'public', 'index.html'), 'utf-8');
+    res.send(html.replace(/{{APP_TITLE}}/g, APP_TITLE));
+  } catch {
+    res.status(500).send('Index not found');
+  }
+});
 
 app.use(express.static(path.join(__dirname, 'public')));
 


### PR DESCRIPTION
## Summary
- allow customizing the UI title through `APP_TITLE`
- replace hard-coded title in index.html with placeholder
- document new variable in README and `.env` example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685c047c4a8c832893bb253fcbef1942