### PR TITLE
Fix #20: Document production Docker deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ Mapping du trigramme applicatif, par priorité :
 2. tag court de trois caractères, par exemple `LAB` ;
 3. custom field `trigramme`, `app_code` ou `application_code`.
 
+## Déploiement production Docker
+
+Le fichier `docker-compose.prod.yml` fournit une configuration prête pour la production.
+
+### Variables obligatoires
+
+| Variable | Description | Exemple |
+|----------|-------------|---------|
+| `NEXTAUTH_URL` | URL publique de l'application | `https://landscape.example.com` |
+| `NEXTAUTH_SECRET` | Clé secrète NextAuth (générer avec `openssl rand -base64 32`) | `changeme-generate-a-real-secret` |
+| `AUTH_ENABLED` | Active l'authentification | `true` |
+| `IT_LANDSCAPE_ENV` | Environnement cible | `production` |
+
+### Lancement
+
+```bash
+cp .env.example .env
+# Éditer .env avec les vraies valeurs de production
+docker compose -f docker-compose.prod.yml up -d --build
+```
+
+> **⚠️ Avant toute mise en production**, remplacez les comptes par défaut (`admin`/`password`, etc.) dans `data/auth/access-rules.json`. Les identifiants de démonstration sont bloquants en production.
+
+Pour plus de détails sur la sécurisation : [SECURITY.md](SECURITY.md) · [docs/security.md](docs/security.md).
+
 ## Tests
 
 ```bash


### PR DESCRIPTION
## Summary

Add a production Docker deployment section to README.md covering required environment variables, docker compose command, default credentials warning, and links to security docs.

## Approach

Add a new section in README.md titled '## Déploiement production Docker' (or similar) that covers: 1) A table or list of required environment variables (NEXTAUTH_URL, NEXTAUTH_SECRET, AUTH_ENABLED, IT_LANDSCAPE_ENV) with placeholder values and descriptions, 2) A copyable docker compose command using docker-compose.prod.yml, 3) A warning that the default admin/password credentials must be changed before production use, 4) Links to SECURITY.md and docs/security.md for further security guidance. The section should be inserted after the existing local development/Docker instructions and before less related sections. No real secrets will appear in examples.

## Files Changed

- `README.md`

## Related Issue

Fixes #20

## Testing

Verified the change manually. Let me know if you'd like any additional tests or adjustments.
