### PR TITLE
feat(admin): add aria-labels to short admin buttons

### DIFF
--- a/pages/admin-habilitations.js
+++ b/pages/admin-habilitations.js
@@ -216,7 +216,8 @@ export default function AdminHabilitations() {
                     </div>
                     <button className="admin-btn danger sm"
                       onClick={() => deleteUser(user.username)}
-                      disabled={saving === `del-${user.username}`}>
+                      disabled={saving === `del-${user.username}`}
+                      aria-label={`Supprimer l'utilisateur ${user.username}`}>
                       {saving === `del-${user.username}` ? '…' : 'Supprimer'}
                     </button>
                   </div>

--- a/pages/admin-metier.js
+++ b/pages/admin-metier.js
@@ -176,7 +176,11 @@ export default function AdminMetier() {
                         <summary className="tree-summary">
                           <span className="tree-label">{dom.nom}</span>
                           <span className="tree-actions">
-                            <button className="admin-btn ghost sm" onClick={e => { e.stopPropagation(); editProcess(eIdx, dIdx, null); }}>
+                            <button
+                              className="admin-btn ghost sm"
+                              onClick={e => { e.stopPropagation(); editProcess(eIdx, dIdx, null); }}
+                              aria-label={`Ajouter un processus dans le domaine ${dom.nom}`}
+                            >
                               + Processus
                             </button>
                           </span>
@@ -190,9 +194,21 @@ export default function AdminMetier() {
                                   <span className="admin-badge accent" style={{ marginLeft: 8 }}>{proc.applications.length}</span>
                                 </span>
                                 <span className="tree-actions">
-                                  <button className="admin-btn ghost sm" onClick={e => { e.stopPropagation(); editApp(eIdx, dIdx, pIdx, null); }}>+ App</button>
-                                  <button className="admin-btn ghost sm" onClick={e => { e.stopPropagation(); editProcess(eIdx, dIdx, pIdx); }}>Éditer</button>
-                                  <button className="admin-btn danger sm" onClick={e => { e.stopPropagation(); if (confirm('Supprimer ce processus ?')) delAtPath(['etablissements', eIdx, 'domaines', dIdx, 'processus', pIdx]); }}>Supprimer</button>
+                                  <button
+                                    className="admin-btn ghost sm"
+                                    onClick={e => { e.stopPropagation(); editApp(eIdx, dIdx, pIdx, null); }}
+                                    aria-label={`Ajouter une application au processus ${proc.nom}`}
+                                  >+ App</button>
+                                  <button
+                                    className="admin-btn ghost sm"
+                                    onClick={e => { e.stopPropagation(); editProcess(eIdx, dIdx, pIdx); }}
+                                    aria-label={`Éditer le processus ${proc.nom}`}
+                                  >Éditer</button>
+                                  <button
+                                    className="admin-btn danger sm"
+                                    onClick={e => { e.stopPropagation(); if (confirm('Supprimer ce processus ?')) delAtPath(['etablissements', eIdx, 'domaines', dIdx, 'processus', pIdx]); }}
+                                    aria-label={`Supprimer le processus ${proc.nom}`}
+                                  >Supprimer</button>
                                 </span>
                               </summary>
                               <ul className="app-list">
@@ -204,8 +220,16 @@ export default function AdminMetier() {
                                       {app.criticite === 'Critique' && <span className="admin-badge danger" style={{ marginLeft: 6 }}>Critique</span>}
                                     </span>
                                     <span className="tree-actions">
-                                      <button className="admin-btn ghost sm" onClick={() => editApp(eIdx, dIdx, pIdx, aIdx)}>Éditer</button>
-                                      <button className="admin-btn danger sm" onClick={() => { if (confirm('Supprimer cette application ?')) delAtPath(['etablissements', eIdx, 'domaines', dIdx, 'processus', pIdx, 'applications', aIdx]); }}>Supprimer</button>
+                                      <button
+                                        className="admin-btn ghost sm"
+                                        onClick={() => editApp(eIdx, dIdx, pIdx, aIdx)}
+                                        aria-label={`Éditer l'application ${app.nom}`}
+                                      >Éditer</button>
+                                      <button
+                                        className="admin-btn danger sm"
+                                        onClick={() => { if (confirm('Supprimer cette application ?')) delAtPath(['etablissements', eIdx, 'domaines', dIdx, 'processus', pIdx, 'applications', aIdx]); }}
+                                        aria-label={`Supprimer l'application ${app.nom}`}
+                                      >Supprimer</button>
                                     </span>
                                   </li>
                                 ))}
@@ -224,12 +248,12 @@ export default function AdminMetier() {
       </main>
 
       {/* Dialog */}
-      <dialog ref={dlgRef} className="admin-dialog" onCancel={() => setEdit(null)}>
+      <dialog ref={dlgRef} className="admin-dialog" onCancel={() => setEdit(null)} aria-labelledby="admin-metier-dialog-title">
         {edit && (
           <form onSubmit={handleSubmit} key={edit.path?.join('/')}>
             <div className="admin-dialog-head">
               <span className="business-section-kicker">{edit.isNew ? 'Nouveau' : 'Modifier'}</span>
-              <h2>{edit.type === 'process' ? 'Processus' : 'Application'}</h2>
+              <h2 id="admin-metier-dialog-title">{edit.type === 'process' ? 'Processus' : 'Application'}</h2>
             </div>
             <div className="admin-dialog-body admin-form-stack">
               <label className="admin-label">


### PR DESCRIPTION
## Summary

Adds context-aware `aria-label` attributes to the short admin buttons on `/admin-metier` (`+ Processus`, `+ App`, `Éditer`, `Supprimer` for processes and applications) and the `Supprimer` button on `/admin-habilitations`. Also adds `aria-labelledby` on the admin-metier edit dialog so its name is announced from the existing `<h2>` instead of the empty default.

## Why this matters

Issue #21 calls out the admin tree views: short buttons like `+ App` are visually unambiguous when the user can see the surrounding `<details>` row, but a screen reader hits the standalone "Plus App" string with no context. The same pattern applies to every short `Éditer` / `Supprimer` button in the tree -- the visible label says "Edit" but the user has no way to tell which process or application is about to change. The user-row delete button on `/admin-habilitations` has the same shape.

The fix matches the issue's "Pistes" exactly: add `aria-label` to short buttons, verify focus on the dialog, no heavy functional changes. Visible button text is preserved so sighted users see the same UI; the new context lives only in the accessible name.

## Changes

`pages/admin-metier.js`:

- `+ Processus` button now carries `aria-label="Ajouter un processus dans le domaine ${dom.nom}"`.
- `+ App` button now carries `aria-label="Ajouter une application au processus ${proc.nom}"`.
- The `Éditer` button on the process row reads `aria-label="Éditer le processus ${proc.nom}"`.
- The `Supprimer` button on the process row reads `aria-label="Supprimer le processus ${proc.nom}"`.
- The `Éditer` button on the app row reads `aria-label="Éditer l'application ${app.nom}"`.
- The `Supprimer` button on the app row reads `aria-label="Supprimer l'application ${app.nom}"`.
- The edit `<dialog>` adds `aria-labelledby="admin-metier-dialog-title"`, and the existing `<h2>` inside the dialog gets `id="admin-metier-dialog-title"`. The heading text already switches between "Processus" and "Application" plus the "Nouveau" / "Modifier" kicker, so screen readers now announce the right title at open time without any new strings.

`pages/admin-habilitations.js`:

- The user-row delete button gets `aria-label="Supprimer l'utilisateur ${user.username}"`. The visible label is unchanged (still "Supprimer", or "…" while the request is in flight).

No other changes. No CSS, no event handlers, no new state. The `confirm('Supprimer ce processus ?')` and `confirm('Supprimer cette application ?')` modal prompts already surface the destructive action to all users; the new aria-labels make the trigger button itself announceable.

## Testing

I do not have a Next.js dev environment in this checkout (no `node_modules/`), so I did not run `pnpm dev` / `next build` end-to-end. JSX braces and parens balance on both touched files (counted with a small Python pass). Manual screen-reader test plan for a reviewer:

- `/admin-metier`: tab through a domain. The `+ Processus` button announces the domain name. Open a process. The `+ App`, `Éditer`, `Supprimer` buttons announce the process name; the per-app `Éditer`, `Supprimer` buttons announce the app name. Activate an `Éditer` button, confirm the dialog opens with the correct name announced via the labelled heading.
- `/admin-habilitations`: tab to a user row. The danger button announces "Supprimer l'utilisateur \<username\>" instead of just "Supprimer".

Closes #21
