### PR TITLE
[codex] Add NetBox reconciliation center

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ MVP Next.js pour cartographier un système d'information hospitalier : applicati
 
 ![Vue réseau](docs/assets/gifs/screen-network.gif)
 
+### Data Quality Center
+
+![Data Quality Center](docs/assets/gifs/screen-quality.gif)
+
 ### Simulation d'incident
 
 ![Simulation d'incident](docs/assets/gifs/screen-incident.gif)

--- a/components/AdminNav.js
+++ b/components/AdminNav.js
@@ -6,6 +6,7 @@ const NAV_ITEMS = [
   { href: '/admin-metier',    label: 'Vue métier' },
   { href: '/admin-flux',      label: 'Flux' },
   { href: '/admin-trigramme', label: 'Trigrammes' },
+  { href: '/admin-netbox-reconciliation', label: 'Réconciliation NetBox' },
 ];
 
 export default function AdminNav({ onLogout }) {

--- a/data/auth/auth-config.json
+++ b/data/auth/auth-config.json
@@ -9,6 +9,7 @@
     "/admin-infra",
     "/admin-flux",
     "/admin-trigramme",
+    "/admin-netbox-reconciliation",
     "/admin-habilitations"
   ],
   "protectedApiRoutes": [
@@ -17,6 +18,7 @@
     "/api/files",
     "/api/flux",
     "/api/quality",
+    "/api/netbox-reconciliation",
     "/api/file",
     "/api/admin/roles"
   ]

--- a/lib/netbox.js
+++ b/lib/netbox.js
@@ -208,4 +208,23 @@ export async function getNetworkFromNetbox() {
   return { etablissements: Array.from(bySite.values()) };
 }
 
+export async function getNetboxReconciliationSnapshot() {
+  const [sites, devices, vms, vlans, prefixes] = await Promise.all([
+    netboxGet('dcim/sites/'),
+    netboxGet('dcim/devices/', { status: 'active' }),
+    netboxGet('virtualization/virtual-machines/', { status: 'active' }),
+    netboxGet('ipam/vlans/'),
+    netboxGet('ipam/prefixes/'),
+  ]);
+
+  return {
+    tagPrefix: NETBOX_TRIGRAMME_PREFIX,
+    sites,
+    devices,
+    virtualMachines: vms,
+    vlans,
+    prefixes,
+  };
+}
+
 export { getNetboxConfig, isNetboxEnabled };

--- a/lib/netboxReconciliation.js
+++ b/lib/netboxReconciliation.js
@@ -1,0 +1,395 @@
+import { flattenLandscape } from './quality/flatteners.js';
+import { blank, normalizeTrig } from './quality/helpers.js';
+
+const TRIGRAMME_RE = /^[A-Z0-9]{3}$/;
+
+const SEVERITY_WEIGHT = {
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+function tagName(tag) {
+  return typeof tag === 'string' ? tag : tag?.name || tag?.slug || '';
+}
+
+function splitIp(address = '') {
+  return String(address || '').split('/')[0];
+}
+
+function ipToInt(ip) {
+  if (!ip || !/^\d+\.\d+\.\d+\.\d+$/.test(ip)) return null;
+  return ip.split('.').reduce((acc, oct) => (acc << 8) + Number(oct), 0) >>> 0;
+}
+
+function ipInCidr(ip, cidr) {
+  const ipInt = ipToInt(ip);
+  if (ipInt === null || !cidr || !cidr.includes('/')) return false;
+  const [network, bitsRaw] = cidr.split('/');
+  const networkInt = ipToInt(network);
+  const bits = Number(bitsRaw);
+  if (networkInt === null || Number.isNaN(bits) || bits < 0 || bits > 32) return false;
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return (ipInt & mask) === (networkInt & mask);
+}
+
+function objectLabel(object) {
+  return object.name || object.display || object.url || `#${object.id || 'inconnu'}`;
+}
+
+function siteLabel(object) {
+  return object.site?.name || object.site?.display || object.site?.slug || '';
+}
+
+function objectPrimaryIp(object) {
+  return splitIp(object.primary_ip4?.address || object.primary_ip?.address);
+}
+
+function objectDescription(object) {
+  return [
+    object.name,
+    object.description,
+    object.comments,
+    object.role?.name,
+    object.device_type?.display,
+  ].filter(Boolean).join(' ');
+}
+
+function normalizeSearchText(value) {
+  return String(value || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function extractCustomCode(object) {
+  const cf = object.custom_fields || {};
+  return cf.trigramme || cf.app_code || cf.application_code || '';
+}
+
+function extractSignals(object, tagPrefix) {
+  const tags = (object.tags || []).map(tagName).filter(Boolean);
+  const prefixedTags = tags
+    .filter(name => name.toLowerCase().startsWith(tagPrefix.toLowerCase()))
+    .map(name => normalizeTrig(name.slice(tagPrefix.length)));
+  const bareTrigrammeTags = tags.filter(name => TRIGRAMME_RE.test(normalizeTrig(name))).map(normalizeTrig);
+  const customCode = normalizeTrig(extractCustomCode(object));
+  const signals = [...prefixedTags, ...bareTrigrammeTags, customCode].filter(Boolean);
+
+  return {
+    tags,
+    prefixedTags,
+    bareTrigrammeTags,
+    customCode,
+    signals,
+    uniqueSignals: [...new Set(signals)],
+    invalidPrefixedTags: tags
+      .filter(name => name.toLowerCase().startsWith(tagPrefix.toLowerCase()))
+      .filter(name => !TRIGRAMME_RE.test(normalizeTrig(name.slice(tagPrefix.length)))),
+  };
+}
+
+function buildApplicationIndex(landscape) {
+  const { applications } = flattenLandscape(landscape);
+  const byTrig = new Map();
+  const nameCandidates = [];
+
+  applications.forEach(app => {
+    if (!app.trigramme) return;
+    byTrig.set(app.trigramme, app);
+    if (app.nom) {
+      nameCandidates.push({
+        trigramme: app.trigramme,
+        name: app.nom,
+        normalizedName: normalizeSearchText(app.nom),
+      });
+    }
+  });
+
+  return { byTrig, nameCandidates };
+}
+
+function suggestMapping(object, appIndex) {
+  const text = normalizeSearchText(objectDescription(object));
+  if (!text) return null;
+
+  for (const trigramme of appIndex.byTrig.keys()) {
+    if (text.includes(trigramme.toLowerCase())) {
+      const app = appIndex.byTrig.get(trigramme);
+      return {
+        trigramme,
+        label: app?.nom || trigramme,
+        reason: `Le libellé contient le trigramme ${trigramme}.`,
+      };
+    }
+  }
+
+  const byName = appIndex.nameCandidates.find(candidate => (
+    candidate.normalizedName.length >= 4 && text.includes(candidate.normalizedName)
+  ));
+  if (!byName) return null;
+
+  return {
+    trigramme: byName.trigramme,
+    label: byName.name,
+    reason: `Le libellé ressemble à l'application ${byName.name}.`,
+  };
+}
+
+function issue({ type, severity = 'medium', title, detail, entity, entityType, site, recommendation, suggestion }) {
+  return {
+    id: `${type}:${entityType}:${entity}:${detail}`.toLowerCase().replace(/\s+/g, '-'),
+    type,
+    severity,
+    title,
+    detail,
+    entity,
+    entityType,
+    site: site || 'Non rattaché',
+    recommendation,
+    suggestion,
+  };
+}
+
+function sortIssues(a, b) {
+  const severityDelta = SEVERITY_WEIGHT[b.severity] - SEVERITY_WEIGHT[a.severity];
+  if (severityDelta !== 0) return severityDelta;
+  return String(a.entity).localeCompare(String(b.entity));
+}
+
+function vlanLabel(vlan) {
+  const id = vlan.vid || vlan.id || '?';
+  return `${vlan.name || vlan.display || 'VLAN'} (${id})`;
+}
+
+function buildVlanUsage({ vlans, prefixes, computeObjects }) {
+  const prefixesByVlan = new Map();
+  prefixes.forEach(prefix => {
+    const vlanId = prefix.vlan?.id;
+    if (!vlanId) return;
+    if (!prefixesByVlan.has(vlanId)) prefixesByVlan.set(vlanId, []);
+    prefixesByVlan.get(vlanId).push(prefix.prefix);
+  });
+
+  return vlans.map(vlan => {
+    const cidrs = prefixesByVlan.get(vlan.id) || [];
+    const members = computeObjects.filter(object => {
+      const ip = objectPrimaryIp(object);
+      return ip && cidrs.some(cidr => ipInCidr(ip, cidr));
+    });
+    return { vlan, cidrs, members };
+  });
+}
+
+export function analyzeNetboxReconciliation({
+  landscape = { etablissements: [] },
+  netbox = {},
+  tagPrefix = 'app:',
+} = {}) {
+  const appIndex = buildApplicationIndex(landscape);
+  const virtualMachines = netbox.virtualMachines || netbox.vms || [];
+  const devices = netbox.devices || [];
+  const vlans = netbox.vlans || [];
+  const prefixes = netbox.prefixes || [];
+  const computeObjects = [
+    ...virtualMachines.map(object => ({ ...object, __type: 'VM' })),
+    ...devices.map(object => ({ ...object, __type: 'Device' })),
+  ];
+
+  const issues = [];
+  const suggestions = [];
+
+  computeObjects.forEach(object => {
+    const entity = objectLabel(object);
+    const entityType = object.__type;
+    const site = siteLabel(object);
+    const signals = extractSignals(object, tagPrefix);
+    const mappingSuggestion = suggestMapping(object, appIndex);
+
+    if (entityType === 'VM' && signals.uniqueSignals.length === 0) {
+      issues.push(issue({
+        type: 'vm-missing-trigramme',
+        severity: 'high',
+        title: 'VM NetBox sans trigramme',
+        detail: `${entity} ne porte aucun tag ${tagPrefix} ni custom field applicatif.`,
+        entity,
+        entityType,
+        site,
+        recommendation: 'Ajouter un tag applicatif ou renseigner le custom field trigramme/app_code.',
+        suggestion: mappingSuggestion,
+      }));
+    }
+
+    if (!site) {
+      issues.push(issue({
+        type: 'unattached-object',
+        severity: 'high',
+        title: 'Objet NetBox non rattaché',
+        detail: `${entity} n'est rattaché à aucun site NetBox.`,
+        entity,
+        entityType,
+        site,
+        recommendation: 'Rattacher l’objet au site/établissement correspondant.',
+        suggestion: mappingSuggestion,
+      }));
+    }
+
+    if (signals.invalidPrefixedTags.length > 0) {
+      issues.push(issue({
+        type: 'inconsistent-tags',
+        severity: 'medium',
+        title: 'Tag applicatif invalide',
+        detail: `${entity} porte un tag applicatif invalide : ${signals.invalidPrefixedTags.join(', ')}.`,
+        entity,
+        entityType,
+        site,
+        recommendation: `Utiliser le format ${tagPrefix}XXX avec un trigramme sur 3 caractères.`,
+        suggestion: mappingSuggestion,
+      }));
+    }
+
+    if (signals.uniqueSignals.length > 1) {
+      issues.push(issue({
+        type: 'inconsistent-tags',
+        severity: 'high',
+        title: 'Tags applicatifs incohérents',
+        detail: `${entity} expose plusieurs mappings applicatifs : ${signals.uniqueSignals.join(', ')}.`,
+        entity,
+        entityType,
+        site,
+        recommendation: 'Conserver un seul trigramme applicatif cohérent entre tags et custom fields.',
+        suggestion: mappingSuggestion,
+      }));
+    }
+
+    signals.uniqueSignals.forEach(trigramme => {
+      if (!appIndex.byTrig.has(trigramme)) {
+        issues.push(issue({
+          type: 'inconsistent-tags',
+          severity: 'medium',
+          title: 'Mapping absent de la cartographie applicative',
+          detail: `${entity} référence ${trigramme}, absent de la cartographie applicative.`,
+          entity,
+          entityType,
+          site,
+          recommendation: 'Corriger le tag/custom field ou créer la fiche applicative correspondante.',
+          suggestion: mappingSuggestion,
+        }));
+      }
+    });
+
+    if (blank(signals.customCode)) {
+      issues.push(issue({
+        type: 'missing-custom-field',
+        severity: 'low',
+        title: 'Custom field applicatif manquant',
+        detail: `${entity} n'a pas de custom field trigramme/app_code/application_code.`,
+        entity,
+        entityType,
+        site,
+        recommendation: 'Renseigner un custom field applicatif pour stabiliser les synchronisations.',
+        suggestion: mappingSuggestion,
+      }));
+    }
+
+    if (mappingSuggestion && signals.uniqueSignals.length === 0) {
+      suggestions.push({
+        entity,
+        entityType,
+        site: site || 'Non rattaché',
+        trigramme: mappingSuggestion.trigramme,
+        label: mappingSuggestion.label,
+        reason: mappingSuggestion.reason,
+      });
+    }
+  });
+
+  vlans.forEach(vlan => {
+    if (!siteLabel(vlan)) {
+      issues.push(issue({
+        type: 'unattached-object',
+        severity: 'medium',
+        title: 'VLAN NetBox non rattaché',
+        detail: `${vlanLabel(vlan)} n'est rattaché à aucun site NetBox.`,
+        entity: vlanLabel(vlan),
+        entityType: 'VLAN',
+        site: siteLabel(vlan),
+        recommendation: 'Rattacher le VLAN au site/établissement correspondant.',
+      }));
+    }
+  });
+
+  prefixes.forEach(prefix => {
+    if (!prefix.site?.name && !prefix.scope?.name) {
+      issues.push(issue({
+        type: 'unattached-object',
+        severity: 'low',
+        title: 'Préfixe NetBox non rattaché',
+        detail: `${prefix.prefix || prefix.display || 'Préfixe'} n'a ni site ni scope explicite.`,
+        entity: prefix.prefix || prefix.display || `#${prefix.id}`,
+        entityType: 'Préfixe',
+        site: '',
+        recommendation: 'Rattacher le préfixe à un site, scope ou VLAN exploitable.',
+      }));
+    }
+  });
+
+  buildVlanUsage({ vlans, prefixes, computeObjects }).forEach(({ vlan, cidrs, members }) => {
+    const mappedMembers = members
+      .map(member => ({ member, signals: extractSignals(member, tagPrefix) }))
+      .filter(({ signals }) => signals.uniqueSignals.some(trigramme => appIndex.byTrig.has(trigramme)));
+
+    if (mappedMembers.length > 0) return;
+
+    const memberSignals = members
+      .flatMap(member => extractSignals(member, tagPrefix).uniqueSignals)
+      .filter(Boolean);
+    const candidate = memberSignals[0] ? {
+      trigramme: memberSignals[0],
+      label: appIndex.byTrig.get(memberSignals[0])?.nom || memberSignals[0],
+      reason: 'Un objet du VLAN porte ce trigramme, mais il n’est pas exploitable dans la cartographie.',
+    } : null;
+
+    issues.push(issue({
+      type: 'vlan-without-app-usage',
+      severity: cidrs.length === 0 ? 'medium' : 'low',
+      title: 'VLAN sans usage applicatif',
+      detail: `${vlanLabel(vlan)} ne contient aucun objet rattaché à une application cartographiée.`,
+      entity: vlanLabel(vlan),
+      entityType: 'VLAN',
+      site: siteLabel(vlan),
+      recommendation: cidrs.length === 0
+        ? 'Associer au moins un préfixe au VLAN ou documenter son usage.'
+        : 'Associer les VM/devices du VLAN aux bons trigrammes applicatifs.',
+      suggestion: candidate,
+    }));
+  });
+
+  const uniqueIssues = Array.from(new Map(issues.map(item => [item.id, item])).values()).sort(sortIssues);
+  const severityCounts = Object.fromEntries(
+    Object.keys(SEVERITY_WEIGHT).map(severity => [
+      severity,
+      uniqueIssues.filter(item => item.severity === severity).length,
+    ]),
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    tagPrefix,
+    metrics: {
+      applications: appIndex.byTrig.size,
+      virtualMachines: virtualMachines.length,
+      devices: devices.length,
+      vlans: vlans.length,
+      prefixes: prefixes.length,
+      issues: uniqueIssues.length,
+      suggestions: suggestions.length,
+      severityCounts,
+    },
+    issues: uniqueIssues,
+    suggestions,
+  };
+}

--- a/next.config.js
+++ b/next.config.js
@@ -18,6 +18,11 @@ const nextConfig = {
         destination: '/incident',
         permanent: false,
       },
+      {
+        source: '/netbox-reconciliation',
+        destination: '/admin-netbox-reconciliation',
+        permanent: false,
+      },
     ];
   },
   async headers() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint",
     "prestart": "node scripts/startup-security-check.mjs",
     "start": "next start -p 3000",
-    "test": "node test/check-data.cjs && node test/check-access-control.mjs && node test/rbac-audit.mjs && node test/json-file-store.mjs && node test/access-control-runtime.mjs && node test/data-quality.mjs && node test/markdown-reports.mjs && node test/startup-security-check.mjs && node test/check-schemas.mjs",
+    "test": "node test/check-data.cjs && node test/check-access-control.mjs && node test/rbac-audit.mjs && node test/json-file-store.mjs && node test/access-control-runtime.mjs && node test/data-quality.mjs && node test/markdown-reports.mjs && node test/netbox-reconciliation.mjs && node test/startup-security-check.mjs && node test/check-schemas.mjs",
     "check:trigrammes": "node check-trigrammes.js data",
     "check:infra-missing-trigramme": "node check-infra-missing-trigramme.js data"
   },

--- a/pages/admin-netbox-reconciliation.js
+++ b/pages/admin-netbox-reconciliation.js
@@ -1,0 +1,255 @@
+import { useEffect, useMemo, useState } from 'react';
+import Head from 'next/head';
+import { motion } from 'framer-motion';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  GitCompareArrows,
+  Lightbulb,
+  Network,
+  Server,
+  Tags,
+} from 'lucide-react';
+import AdminNav from '../components/AdminNav';
+import { LOGO_URL, ORG_NAME, APP_TITLE } from '../lib/branding';
+
+const SEVERITY_CLASS = {
+  critical: 'danger',
+  high: 'warning',
+  medium: 'notice',
+  low: 'quiet',
+};
+
+const SEVERITY_LABEL = {
+  critical: 'Critique',
+  high: 'Forte',
+  medium: 'Moyenne',
+  low: 'Faible',
+};
+
+const TYPE_LABEL = {
+  'vm-missing-trigramme': 'VM sans trigramme',
+  'vlan-without-app-usage': 'VLAN sans usage',
+  'unattached-object': 'Objets non rattachés',
+  'inconsistent-tags': 'Tags incohérents',
+  'missing-custom-field': 'Custom fields manquants',
+};
+
+function formatDate(value) {
+  if (!value) return 'Non calculé';
+  return new Intl.DateTimeFormat('fr-FR', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+function sourceStatus(netbox) {
+  if (netbox?.enabled) return 'NetBox connecté';
+  if (!netbox?.hasUrl && !netbox?.hasToken) return 'NetBox non configuré';
+  if (!netbox?.hasUrl) return 'NETBOX_URL manquant';
+  if (!netbox?.hasToken) return 'NETBOX_TOKEN manquant';
+  return 'Configuration incomplète';
+}
+
+export default function AdminNetboxReconciliationPage() {
+  const [analysis, setAnalysis] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/netbox-reconciliation')
+      .then(async response => {
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload?.error || 'Erreur réconciliation NetBox');
+        return payload;
+      })
+      .then(payload => {
+        if (!cancelled) setAnalysis(payload);
+      })
+      .catch(err => {
+        if (!cancelled) setError(err.message);
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  const groupedIssues = useMemo(() => {
+    const groups = new Map();
+    for (const issue of analysis?.issues || []) {
+      const key = issue.type || 'other';
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(issue);
+    }
+    return Array.from(groups.entries()).map(([type, issues]) => ({ type, issues }));
+  }, [analysis]);
+
+  const handleLogout = async () => {
+    await fetch('/api/auth/logout');
+    window.location.href = '/login';
+  };
+
+  return (
+    <>
+      <Head>
+        <title>{`NetBox Reconciliation Center - ${APP_TITLE}`}</title>
+        <meta charSet="UTF-8" />
+      </Head>
+      <header className="hero business-hero reconciliation-hero">
+        <div className="page-shell hero-grid">
+          <div className="hero-brand">
+            <div className="brand-mark">
+              {LOGO_URL && <img src={LOGO_URL} alt={ORG_NAME} />}
+            </div>
+            <div>
+              <p className="eyebrow">{ORG_NAME}</p>
+              <motion.h1 initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.5 }}>
+                NetBox Reconciliation Center
+              </motion.h1>
+              <p className="hero-subtitle">
+                Comparez NetBox avec la cartographie applicative et priorisez les corrections de mapping.
+              </p>
+            </div>
+          </div>
+          <AdminNav onLogout={handleLogout} />
+        </div>
+      </header>
+
+      {error && (
+        <section className="page-shell quality-error">
+          <AlertTriangle size={20} aria-hidden="true" />
+          <span>{error}</span>
+        </section>
+      )}
+
+      {!analysis && !error && (
+        <section className="page-shell quality-loading">
+          <GitCompareArrows size={22} aria-hidden="true" />
+          <span>Comparaison NetBox / cartographie...</span>
+        </section>
+      )}
+
+      {analysis && (
+        <>
+          <section className="business-command-center reconciliation-command-center page-shell">
+            <div className="business-command-intro">
+              <span className="business-section-kicker">Réconciliation</span>
+              <h2>{sourceStatus(analysis.netbox)}</h2>
+              <p>
+                Dernier calcul : {formatDate(analysis.generatedAt)}. Préfixe tag applicatif : {analysis.tagPrefix || 'app:'}
+              </p>
+            </div>
+            <div className="business-kpi-grid reconciliation-kpi-grid" aria-label="Synthèse réconciliation">
+              <article className="business-kpi-card highlight">
+                <span>Écarts</span>
+                <strong>{analysis.metrics.issues}</strong>
+                <em>{analysis.metrics.severityCounts.high || 0} forte(s)</em>
+              </article>
+              <article className="business-kpi-card">
+                <span>Suggestions</span>
+                <strong>{analysis.metrics.suggestions}</strong>
+                <em>Mappings proposés</em>
+              </article>
+              <article className="business-kpi-card">
+                <span>VM / Devices</span>
+                <strong>{analysis.metrics.virtualMachines + analysis.metrics.devices}</strong>
+                <em>{analysis.metrics.virtualMachines} VM</em>
+              </article>
+              <article className="business-kpi-card">
+                <span>VLANs</span>
+                <strong>{analysis.metrics.vlans}</strong>
+                <em>{analysis.metrics.prefixes} préfixe(s)</em>
+              </article>
+            </div>
+          </section>
+
+          {!analysis.netbox?.enabled && (
+            <section className="page-shell reconciliation-empty">
+              <AlertTriangle size={22} aria-hidden="true" />
+              <div>
+                <strong>NetBox n’est pas configuré.</strong>
+                <p>Définissez `NETBOX_URL` et `NETBOX_TOKEN` pour lancer la comparaison avec l’inventaire NetBox.</p>
+              </div>
+            </section>
+          )}
+
+          {analysis.netbox?.enabled && (
+            <main className="page-shell reconciliation-grid">
+              <section className="quality-panel reconciliation-panel">
+                <div className="business-panel-header">
+                  <div>
+                    <span className="business-section-kicker">Écarts détectés</span>
+                    <h2>Contrôles NetBox</h2>
+                  </div>
+                  <Network size={22} aria-hidden="true" />
+                </div>
+                {groupedIssues.length === 0 ? (
+                  <p className="quality-empty"><CheckCircle2 size={18} aria-hidden="true" /> Aucun écart détecté.</p>
+                ) : groupedIssues.map(group => (
+                  <article className="reconciliation-group" key={group.type}>
+                    <div className="reconciliation-group-header">
+                      <strong>{TYPE_LABEL[group.type] || group.type}</strong>
+                      <span>{group.issues.length}</span>
+                    </div>
+                    <div className="reconciliation-issue-list">
+                      {group.issues.map(issue => (
+                        <div className="reconciliation-issue" key={issue.id}>
+                          <span className={`quality-severity ${SEVERITY_CLASS[issue.severity]}`}>
+                            {SEVERITY_LABEL[issue.severity] || issue.severity}
+                          </span>
+                          <div>
+                            <strong>{issue.entity}</strong>
+                            <em>{issue.entityType} · {issue.site}</em>
+                            <p>{issue.detail}</p>
+                            <small>{issue.recommendation}</small>
+                            {issue.suggestion && (
+                              <span className="reconciliation-suggestion-inline">
+                                Suggestion : {issue.suggestion.trigramme} · {issue.suggestion.label}
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </article>
+                ))}
+              </section>
+
+              <aside className="quality-panel reconciliation-panel">
+                <div className="business-panel-header">
+                  <div>
+                    <span className="business-section-kicker">Mapping</span>
+                    <h2>Suggestions</h2>
+                  </div>
+                  <Lightbulb size={22} aria-hidden="true" />
+                </div>
+                {analysis.suggestions.length === 0 ? (
+                  <p className="quality-empty"><CheckCircle2 size={18} aria-hidden="true" /> Aucune suggestion automatique.</p>
+                ) : (
+                  <div className="reconciliation-suggestions">
+                    {analysis.suggestions.map(suggestion => (
+                      <article key={`${suggestion.entity}-${suggestion.trigramme}`} className="reconciliation-suggestion">
+                        <span><Tags size={16} aria-hidden="true" /> {suggestion.trigramme}</span>
+                        <strong>{suggestion.entity}</strong>
+                        <p>{suggestion.label}</p>
+                        <small>{suggestion.reason}</small>
+                      </article>
+                    ))}
+                  </div>
+                )}
+
+                <div className="reconciliation-scope">
+                  <h3>Périmètre NetBox</h3>
+                  <ul>
+                    <li><Server size={16} aria-hidden="true" /> {analysis.metrics.virtualMachines} VM actives</li>
+                    <li><Server size={16} aria-hidden="true" /> {analysis.metrics.devices} devices actifs</li>
+                    <li><Network size={16} aria-hidden="true" /> {analysis.metrics.vlans} VLANs</li>
+                    <li><Network size={16} aria-hidden="true" /> {analysis.metrics.prefixes} préfixes</li>
+                  </ul>
+                </div>
+              </aside>
+            </main>
+          )}
+        </>
+      )}
+    </>
+  );
+}

--- a/pages/api/netbox-reconciliation.js
+++ b/pages/api/netbox-reconciliation.js
@@ -1,0 +1,95 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { withAuthz } from '../../lib/authz.js';
+import { getDataDir } from '../../lib/dataPaths.js';
+import {
+  getNetboxConfig,
+  getNetboxReconciliationSnapshot,
+} from '../../lib/netbox.js';
+import { analyzeNetboxReconciliation } from '../../lib/netboxReconciliation.js';
+
+async function readJson(filePath, fallback) {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content);
+  } catch {
+    return fallback;
+  }
+}
+
+async function loadLandscape(dataDir) {
+  const files = (await fs.readdir(dataDir)).filter(file =>
+    file.endsWith('.json') &&
+    !file.endsWith('.infra.json') &&
+    !file.endsWith('.network.json') &&
+    !file.endsWith('.flux.json') &&
+    file !== 'trigrammes.json'
+  );
+
+  const etablissements = [];
+  for (const file of files) {
+    const json = await readJson(path.join(dataDir, file), { etablissements: [] });
+    etablissements.push(...(json.etablissements || []));
+  }
+  return { etablissements };
+}
+
+async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const netboxConfig = getNetboxConfig();
+    const dataDir = getDataDir();
+    const landscape = await loadLandscape(dataDir);
+
+    if (!netboxConfig.enabled) {
+      return res.status(200).json({
+        generatedAt: new Date().toISOString(),
+        netbox: {
+          enabled: false,
+          hasUrl: Boolean(netboxConfig.url),
+          hasToken: Boolean(netboxConfig.token),
+          urlSource: netboxConfig.urlSource,
+          tokenSource: netboxConfig.tokenSource,
+        },
+        metrics: {
+          applications: 0,
+          virtualMachines: 0,
+          devices: 0,
+          vlans: 0,
+          prefixes: 0,
+          issues: 0,
+          suggestions: 0,
+          severityCounts: { critical: 0, high: 0, medium: 0, low: 0 },
+        },
+        issues: [],
+        suggestions: [],
+      });
+    }
+
+    const snapshot = await getNetboxReconciliationSnapshot();
+    const analysis = analyzeNetboxReconciliation({
+      landscape,
+      netbox: snapshot,
+      tagPrefix: snapshot.tagPrefix,
+    });
+
+    return res.status(200).json({
+      ...analysis,
+      netbox: {
+        enabled: true,
+        hasUrl: true,
+        hasToken: true,
+        urlSource: netboxConfig.urlSource,
+        tokenSource: netboxConfig.tokenSource,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: 'Erreur réconciliation NetBox' });
+  }
+}
+
+export default withAuthz('write', handler);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2059,6 +2059,171 @@ small { font-size: 12px; line-height: 16px; }
   color: #991b1b;
 }
 
+.reconciliation-hero {
+  padding-bottom: 36px;
+}
+
+.reconciliation-command-center {
+  grid-template-columns: minmax(340px, 0.72fr) minmax(620px, 1.28fr);
+  margin-top: 8px;
+}
+
+.reconciliation-kpi-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.reconciliation-empty {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-top: 24px;
+  border: 1px solid rgba(245, 158, 11, 0.22);
+  border-radius: 22px;
+  background: rgba(255, 251, 235, 0.82);
+  color: #754b00;
+  padding: 18px;
+}
+
+.reconciliation-empty p {
+  margin: 4px 0 0;
+}
+
+.reconciliation-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(340px, 0.65fr);
+  gap: 24px;
+  margin-top: 24px;
+  margin-bottom: 40px;
+}
+
+.reconciliation-panel {
+  min-width: 0;
+}
+
+.reconciliation-group {
+  border-top: 1px solid rgba(10, 46, 74, 0.08);
+  padding: 16px 0 4px;
+}
+
+.reconciliation-group-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.reconciliation-group-header strong {
+  color: var(--color-primary);
+}
+
+.reconciliation-group-header span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 28px;
+  border-radius: 999px;
+  background: #e7f3f1;
+  color: #0a5a62;
+  font-weight: 900;
+}
+
+.reconciliation-issue-list,
+.reconciliation-suggestions {
+  display: grid;
+  gap: 10px;
+}
+
+.reconciliation-issue {
+  display: grid;
+  grid-template-columns: 96px 1fr;
+  gap: 14px;
+  border: 1px solid rgba(10, 46, 74, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 14px;
+}
+
+.reconciliation-issue strong,
+.reconciliation-suggestion strong {
+  color: var(--color-primary);
+}
+
+.reconciliation-issue em,
+.reconciliation-issue small,
+.reconciliation-suggestion small,
+.reconciliation-suggestion p {
+  color: #607989;
+  font-size: 0.86rem;
+  font-style: normal;
+}
+
+.reconciliation-issue p {
+  margin: 5px 0;
+  color: #314b5f;
+}
+
+.reconciliation-suggestion-inline {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: 8px;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #3730a3;
+  font-size: 0.78rem;
+  font-weight: 900;
+  padding: 5px 9px;
+}
+
+.reconciliation-suggestion {
+  display: grid;
+  gap: 5px;
+  border: 1px solid rgba(10, 46, 74, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.76);
+  padding: 14px;
+}
+
+.reconciliation-suggestion span {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  border-radius: 999px;
+  background: #e7f3f1;
+  color: #0a5a62;
+  font-size: 0.8rem;
+  font-weight: 900;
+  padding: 5px 9px;
+}
+
+.reconciliation-suggestion p {
+  margin: 0;
+}
+
+.reconciliation-scope {
+  margin-top: 22px;
+  border-top: 1px solid rgba(10, 46, 74, 0.08);
+  padding-top: 18px;
+}
+
+.reconciliation-scope ul {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.reconciliation-scope li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #36576a;
+  font-weight: 800;
+}
+
 .quality-empty {
   display: inline-flex;
   align-items: center;
@@ -2550,7 +2715,9 @@ small { font-size: 12px; line-height: 16px; }
 
 @media (max-width: 1180px) {
   .business-command-center,
-  .quality-command-center {
+  .quality-command-center,
+  .reconciliation-command-center,
+  .reconciliation-grid {
     grid-template-columns: 1fr;
   }
 
@@ -2579,6 +2746,7 @@ small { font-size: 12px; line-height: 16px; }
 
   .business-kpi-grid,
   .quality-kpi-grid,
+  .reconciliation-kpi-grid,
   .business-app-grid,
   .business-filter-panel .filters-grid,
   .business-domains-condensed {
@@ -2594,7 +2762,8 @@ small { font-size: 12px; line-height: 16px; }
   }
 
   .quality-dimension,
-  .quality-issue {
+  .quality-issue,
+  .reconciliation-issue {
     grid-template-columns: 1fr;
   }
 

--- a/test/netbox-reconciliation.mjs
+++ b/test/netbox-reconciliation.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { analyzeNetboxReconciliation } from '../lib/netboxReconciliation.js';
+
+const landscape = {
+  etablissements: [
+    {
+      nom: 'CH Test',
+      domaines: [
+        {
+          nom: 'Soins',
+          processus: [
+            {
+              nom: 'Dossier patient',
+              applications: [
+                {
+                  nom: 'Dossier Patient Informatisé',
+                  trigramme: 'DPI',
+                  criticite: 'Critique',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const result = analyzeNetboxReconciliation({
+  landscape,
+  netbox: {
+    virtualMachines: [
+      {
+        id: 1,
+        name: 'vm-dossier-patient-informatise-01',
+        site: { id: 1, name: 'CH Test' },
+        tags: [],
+        custom_fields: {},
+        primary_ip4: { address: '10.10.1.10/24' },
+      },
+      {
+        id: 2,
+        name: 'vm-bad-map',
+        site: { id: 1, name: 'CH Test' },
+        tags: [{ name: 'app:DPIS' }, { name: 'app:XYZ' }],
+        custom_fields: { trigramme: 'DPI' },
+        primary_ip4: { address: '10.10.2.10/24' },
+      },
+      {
+        id: 3,
+        name: 'vm-no-site',
+        site: null,
+        tags: [{ name: 'app:DPI' }],
+        custom_fields: { trigramme: 'DPI' },
+        primary_ip4: { address: '10.10.3.10/24' },
+      },
+    ],
+    devices: [
+      {
+        id: 4,
+        name: 'fw-test',
+        site: { id: 1, name: 'CH Test' },
+        tags: [{ name: 'app:DPI' }],
+        custom_fields: {},
+        primary_ip4: { address: '10.10.1.1/24' },
+      },
+    ],
+    vlans: [
+      { id: 10, vid: 10, name: 'VLAN-DPI', site: { id: 1, name: 'CH Test' } },
+      { id: 20, vid: 20, name: 'VLAN-ORPHELIN', site: { id: 1, name: 'CH Test' } },
+      { id: 30, vid: 30, name: 'VLAN-NOSITE', site: null },
+    ],
+    prefixes: [
+      { id: 101, prefix: '10.10.1.0/24', vlan: { id: 10 }, site: { id: 1, name: 'CH Test' } },
+      { id: 102, prefix: '10.10.9.0/24', vlan: { id: 20 }, site: { id: 1, name: 'CH Test' } },
+      { id: 103, prefix: '10.10.30.0/24', vlan: { id: 30 }, site: null },
+    ],
+  },
+  tagPrefix: 'app:',
+});
+
+const types = new Set(result.issues.map(issue => issue.type));
+
+assert.equal(result.metrics.applications, 1);
+assert.equal(result.metrics.virtualMachines, 3);
+assert.equal(result.metrics.devices, 1);
+assert.equal(result.metrics.vlans, 3);
+assert(types.has('vm-missing-trigramme'));
+assert(types.has('vlan-without-app-usage'));
+assert(types.has('unattached-object'));
+assert(types.has('inconsistent-tags'));
+assert(types.has('missing-custom-field'));
+assert(result.suggestions.some(suggestion => suggestion.trigramme === 'DPI'));
+assert(result.issues.some(issue => issue.title === 'Tags applicatifs incohérents'));
+assert(result.issues.some(issue => issue.title === 'Tag applicatif invalide'));
+
+console.log('NetBox reconciliation tests: OK');


### PR DESCRIPTION
## Summary

- add an admin-only NetBox Reconciliation Center at `/admin-netbox-reconciliation`
- compare NetBox VM/device/VLAN/prefix data with the application cartography
- detect missing trigrammes, VLANs without application usage, unattached objects, inconsistent tags, missing custom fields, and mapping suggestions
- add `/api/netbox-reconciliation`, protected for editor/admin users
- add the new Data Quality Center GIF to the README preview section

## Validation

- `node test/netbox-reconciliation.mjs`
- `npm test`
- `npm run lint` (passes with existing `<img>` and `flux.js` hook warnings)
- `npm run build`

## Issue handling

No existing open issue directly matches this feature. Issue #19 is about reducing demo asset weight, so it is intentionally not closed by this PR.
